### PR TITLE
Add MYSQL_CHARSET and MYSQL_COLLATE env vars

### DIFF
--- a/library/mysql.js
+++ b/library/mysql.js
@@ -26,6 +26,20 @@ class MySQLService {
     this.options.serviceWaitInterval = this.options.serviceWaitInterval || 1000;
     this.options.serviceWaitMaxRetries = this.options.serviceWaitMaxRetries || 30;
     this.env = {
+      MYSQL_CHARSET: {
+        key: 'MYSQL_CHARSET',
+        required: false,
+        description: 'Character set used to create a new MySQL database',
+        value: process.env.MYSQL_CHARSET || 'utf8mb4',
+        defaultValue: 'utf8mb4',
+      },
+      MYSQL_COLLATE: {
+        key: 'MYSQL_COLLATE',
+        required: false,
+        description: 'Character collate used to create a new MySQL database',
+        value: process.env.MYSQL_COLLATE || 'utf8mb4_bin',
+        defaultValue: 'utf8mb4_bin',
+      },
       MYSQL_CONTAINER_NAME: {
         key: 'MYSQL_CONTAINER_NAME',
         required: true,
@@ -155,7 +169,7 @@ class MySQLService {
    */
   async _createDatabase() {
     await verifyEnvironment(this.env);
-    const sql = `CREATE DATABASE IF NOT EXISTS ${this.env.MYSQL_DATABASE.value};`;
+    const sql = `CREATE DATABASE IF NOT EXISTS ${this.env.MYSQL_DATABASE.value} CHARACTER SET ${this.env.MYSQL_CHARSET.value} COLLATE ${this.env.MYSQL_COLLATE.value};`;
     const command = `exec \
       -e MYSQL_PWD=${this.env.MYSQL_ROOT_PASSWORD.value} \
       -i ${this.env.MYSQL_CONTAINER_NAME.value} \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Install and manage local services for your development environments",
   "keywords": "node cli docker local service development environment dotenv",
   "main": "./bin/localservice.js",


### PR DESCRIPTION
# Add MYSQL_CHARSET and MYSQL_COLLATE env vars

> Add `MYSQL_CHARSET` and `MYSQL_COLLATE` env vars to make satisfying picky environments easier

* Add `MYSQL_CHARSET` env var support with a default value of `utf8mb4`
* Add `MYSQL_COLLATE` env var support with a default value of `utf8mb4_bin`
* Bump patch version to `0.3.1`

To test change `MYSQL_CHARSET` and `MYSQL_COLLATE` in between remove and create:

[~] npx localservice mysql remove
[~] vi .env
[~] npx localservice mysql create

Then test your setup for the new settings.