### PR TITLE
Refactor `create`, `prepare`, and `seed`

### DIFF
--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -42,8 +42,8 @@ function showUsage() {
   console.info('');
   console.info('  config    Get service container config info');
   console.info('  create    Create new service container');
-  console.info('  prepare   Prepare new service container for first time use');
   console.info('  remove    Remove service container');
+  console.info('  seed      Populate service container with seed data');
   console.info('  start     Start service container');
   console.info('  status    Get service container status info');
   console.info('  stop      Stop service container');
@@ -59,8 +59,8 @@ const commandName = args[1];
 const commands = [
   'config',
   'create',
-  'prepare',
   'remove',
+  'seed',
   'start',
   'status',
   'stop',

--- a/library/util.js
+++ b/library/util.js
@@ -76,8 +76,8 @@ const printConfig = async (displayServiceName, env) => {
     console.info([
       '  ',
       key.padEnd(keyLength),
-      (env[key].defaultValue || '').padEnd(defaultValueLength),
-      (env[key].value || 'none').padEnd(valueLength),
+      (env[key].defaultValue || '').toString().padEnd(defaultValueLength),
+      (env[key].value || 'none').toString().padEnd(valueLength),
       (env[key].required ? 'Y' : 'N').padEnd(11),
     ].join(''));
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Install and manage local services for your development environments",
   "keywords": "node cli docker local service development environment dotenv",
   "main": "./bin/localservice.js",


### PR DESCRIPTION
# Refactor `create`, `prepare`, and `seed`

> Prepare root user in `create`, remove `prepare`, add `seed`, and minor codebase improvements

## Changes

- Add `ALTER USER` statement to `_prepareRootUser` instead of hard coding it in project seed files
- Add `_prepareRootUser` and `_createDatabase` to `create` command
- Remove `prepare` command (prepare logic now resides in `create` command)
- Add `seed` command to execute `MYSQL_SEED_FILES` with
- Expose `serviceWaitInterval` as env var `MYSQL_SERVICE_WAIT_INTERVAL`
- Expose `serviceWaitMaxRetries` as env var `MYSQL_SERVICE_WAIT_MAX_RETRIES`
- Add `try/catch` to `_isServiceReady` to suppress common network delays
- Add `toString()` to `printConfig` to handle non-string env var values
- Bump minor version to `0.4.0`

## Testing

- Run `npx localservice mysql config` to see `MYSQL_SERVICE_WAIT_INTERVAL` and `MYSQL_SERVICE_WAIT_RETRIES`
- Run `npx localservice mysql prepare` to see that the command no longer exists
- Run `npx localservice mysql create` to see that the `root` user now works without `prepare`
- Run `npx localservice mysql create` to see that the `MYSQL_SEED_FILES` are no longer executed
- Run `npx localservice mysql seed` to see that the `MYSQL_SEED_FILES` are still executed