### PR TITLE
Add exit code for improved error handling

### DIFF
--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -71,4 +71,7 @@ if (!serviceName || !commandName || !commands.includes(commandName)) {
 
 // run
 const localService = new LocalService(serviceName, { cwd: process.cwd() });
-localService.service[commandName]().catch((err) => console.error(err.message));
+localService.service[commandName]().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/library/mysql.js
+++ b/library/mysql.js
@@ -159,7 +159,7 @@ class MySQLService {
       await sleep();
     }
     /* eslint-enable no-await-in-loop */
-    throw new Error('MySQL service took too long to start, please try again');
+    throw new Error('MySQL service took too long to start, please try again (or update `MYSQL_SERVICE_WAIT_*` settings)');
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Install and manage local services for your development environments",
   "keywords": "node cli docker local service development environment dotenv",
   "main": "./bin/localservice.js",


### PR DESCRIPTION
# Add exit code for improved error handling

> Add exit code for improved error handling when chaining `npx localservice` shell commands with `&&`

## Changes

- Add `exit 1` to exposed error handler
- Mention use of `MYSQL_SERVICE_WAIT_*` settings in timeout error
- Bump patch version to `0.4.2`

## Testing

- Set `MYSQL_SERVICE_WAIT_INTERVAL` to a low value like `10`
- Set `MYSQL_SERVICE_WAIT_MAX_RETRIES` to a low value like `5`
- Run a non-dependency chain command like `npx localservice mysql create; echo "hello"`
- See that `echo "hello"` will run even though `npx localservice mysql create` timed out
- Run a dependency chain command like `npx localservice mysql create && echo "hello"`
- See that `echo "hello"` will NOT run because `npx localservice mysql create` timed out (and threw exit 1)