### PR TITLE
Rename `seed` to `push`, combine `config`/`status` into `info`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2022 Tobius Ventures
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Commands:
   config    Get service container config info
   create    Create new service container
   remove    Remove service container
-  seed      Populate service container with seed data
+  populate  Populate service container with existing data
   start     Start service container
   status    Get service container status info
   stop      Stop service container

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Services (implemented)
 
 Commands (universal)
   create    Create new service container
-  info      Get service config and container info
+  info      Get service env and container info
   push      Push data to running service container
   remove    Remove existing service container
   start     Start stopped service container

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Commands:
 
   config    Get service container config info
   create    Create new service container
+  push      Push data to service container
   remove    Remove service container
-  populate  Populate service container with existing data
   start     Start service container
   status    Get service container status info
   stop      Stop service container

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install and manage services for your local development environments.
 ## Usage
 
 ```text
-[~] npm install localservice
+[~] npm i localservice
 [~] npx localservice -h
 
 Usage: localservice [options] <service> <command>

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 Install and manage services for your local development environments.
 
-## Pre-requisites
+### Pre-requisites
 
 * Docker
 * Node (14+)
 
-## Setup
+## Usage
 
-```
+```text
 [~] npm install localservice
-[~] npx localservice
+[~] npx localservice -h
 
 Usage: localservice [options] <service> <command>
 
@@ -27,14 +27,44 @@ Services:
 
 Commands:
 
-  config    Get service container config info
   create    Create new service container
+  info      Get service container info
   push      Push data to service container
   remove    Remove service container
   start     Start service container
-  status    Get service container status info
   stop      Stop service container
 ```
+
+### MinIO Environment Variables
+
+Key																| Default	| Description
+---																| ---			| ---
+`MINIO_CONTAINER_NAME`						| _none_	| Name used to identify MinIO Service Docker container
+`MINIO_EXPOSED_PORT`							| 9000		| Local network port used to expose MinIO Service
+`MINIO_EXPOSED_WEB_PORT`					| 9001		| Local network port used to expose MinIO Web tool
+`MINIO_IMAGE`											| _none_	| MinIO Server Docker image for your processor: https://hub.docker.com/r/minio/minio/tags
+`MINIO_PATH`											| _none_	| Path to the preferred MinIO Service library file folder
+`MINIO_ROOT_PASSWORD`							| _none_	| Username to use when creating the MinIO Service root user
+`MINIO_ROOT_USER`									| _none_	| Password to use when creating the MinIO Service root user
+`MINIO_SERVICE_WAIT_INTERVAL`			| 1000		| Number of milliseconds to wait between MinIO service uptime test retries
+`MINIO_SERVICE_WAIT_MAX_RETRIES`	| 30			| Maximum number of times to retry MinIO service uptime test before timing out
+`MINIO_SEED_FILES`								| _none_	| Path to MinIO object storage seed file glob(s) to import during first time setup (separate by commas)
+
+### MySQL Environment Variables
+
+Key																| Default					| Description
+---																| ---							| ---
+`MYSQL_CHARSET`										| utf8mb4					| Character set used to create a new MySQL database
+`MYSQL_COLLATE`										| utf8mb4_bin			| Character collate used to create a new MySQL database
+`MYSQL_CONTAINER_NAME`						| _none_					| Name used to identify MySQL Service Docker container
+`MYSQL_DATABASE`									| _none_					| Name used to identify MySQL Service database
+`MYSQL_EXPOSED_PORT`							| 3306						| Local network port used to expose MySQL Service
+`MYSQL_IMAGE`											| _none_					| MySQL Server Docker image for your processor: https://hub.docker.com/r/mysql/mysql-server/tags
+`MYSQL_PATH`											| /var/lib/mysql	| Path to the preferred MySQL Service library file folder
+`MYSQL_ROOT_PASSWORD`							| _none_					| Password to use when creating the MySQL Service database root user
+`MYSQL_SEED_FILES`								| _none_					| Path to SQL seed file glob(s) to execute during first time setup (separate by commas)
+`MYSQL_SERVICE_WAIT_INTERVAL`			| 1000						| Number of milliseconds to wait between MySQL service uptime test retries
+`MYSQL_SERVICE_WAIT_MAX_RETRIES`	| 30							| Maximum number of times to retry MySQL service uptime test before timing out
 
 <!--
 

--- a/README.md
+++ b/README.md
@@ -15,24 +15,21 @@ Install and manage services for your local development environments.
 
 Usage: localservice [options] <service> <command>
 
-Options:
-
+Options
   -v, --verbose   Show verbose info (e.g. raw docker commands, etc)
   -h, --help      Show this help screen
 
-Services:
-
+Services (implemented)
   minio     MinIO object storage (s3 compatible)
   mysql     MySQL database
 
-Commands:
-
+Commands (universal)
   create    Create new service container
-  info      Get service container info
-  push      Push data to service container
-  remove    Remove service container
-  start     Start service container
-  stop      Stop service container
+  info      Get service config and container info
+  push      Push data to running service container
+  remove    Remove existing service container
+  start     Start stopped service container
+  stop      Stop running service container
 ```
 
 ### MinIO Environment Variables

--- a/README.md
+++ b/README.md
@@ -32,36 +32,38 @@ Commands (universal)
   stop      Stop running service container
 ```
 
-### MinIO Environment Variables
+## Environment Variables
 
-Key																| Default	| Description
----																| ---			| ---
-`MINIO_CONTAINER_NAME`						| _none_	| Name used to identify MinIO Service Docker container
-`MINIO_EXPOSED_PORT`							| 9000		| Local network port used to expose MinIO Service
-`MINIO_EXPOSED_WEB_PORT`					| 9001		| Local network port used to expose MinIO Web tool
-`MINIO_IMAGE`											| _none_	| MinIO Server Docker image for your processor: https://hub.docker.com/r/minio/minio/tags
-`MINIO_PATH`											| _none_	| Path to the preferred MinIO Service library file folder
-`MINIO_ROOT_PASSWORD`							| _none_	| Username to use when creating the MinIO Service root user
-`MINIO_ROOT_USER`									| _none_	| Password to use when creating the MinIO Service root user
-`MINIO_SERVICE_WAIT_INTERVAL`			| 1000		| Number of milliseconds to wait between MinIO service uptime test retries
-`MINIO_SERVICE_WAIT_MAX_RETRIES`	| 30			| Maximum number of times to retry MinIO service uptime test before timing out
-`MINIO_SEED_FILES`								| _none_	| Path to MinIO object storage seed file glob(s) to import during first time setup (separate by commas)
+### MinIO
 
-### MySQL Environment Variables
+Key																| Required	| Default	| Description
+---																| ---				| ---			| ---
+`MINIO_CONTAINER_NAME`						| Y					| _none_	| Name used to identify MinIO Service Docker container
+`MINIO_EXPOSED_PORT`							| Y					| 9000		| Local network port used to expose MinIO Service
+`MINIO_EXPOSED_WEB_PORT`					| Y					| 9001		| Local network port used to expose MinIO Web tool
+`MINIO_IMAGE`											| Y					| _none_	| MinIO Server Docker image for your processor: https://hub.docker.com/r/minio/minio/tags
+`MINIO_PATH`											| Y					| _none_	| Path to the preferred MinIO Service library file folder
+`MINIO_ROOT_PASSWORD`							| Y					| _none_	| Username to use when creating the MinIO Service root user
+`MINIO_ROOT_USER`									| Y					| _none_	| Password to use when creating the MinIO Service root user
+`MINIO_SEED_FILES`								| N					| _none_	| Path to MinIO object storage seed file glob(s) to import during first time setup (separate by commas)
+`MINIO_SERVICE_WAIT_INTERVAL`			| N					| 1000		| Number of milliseconds to wait between MinIO service uptime test retries
+`MINIO_SERVICE_WAIT_MAX_RETRIES`	| N					| 30			| Maximum number of times to retry MinIO service uptime test before timing out
 
-Key																| Default					| Description
----																| ---							| ---
-`MYSQL_CHARSET`										| utf8mb4					| Character set used to create a new MySQL database
-`MYSQL_COLLATE`										| utf8mb4_bin			| Character collate used to create a new MySQL database
-`MYSQL_CONTAINER_NAME`						| _none_					| Name used to identify MySQL Service Docker container
-`MYSQL_DATABASE`									| _none_					| Name used to identify MySQL Service database
-`MYSQL_EXPOSED_PORT`							| 3306						| Local network port used to expose MySQL Service
-`MYSQL_IMAGE`											| _none_					| MySQL Server Docker image for your processor: https://hub.docker.com/r/mysql/mysql-server/tags
-`MYSQL_PATH`											| /var/lib/mysql	| Path to the preferred MySQL Service library file folder
-`MYSQL_ROOT_PASSWORD`							| _none_					| Password to use when creating the MySQL Service database root user
-`MYSQL_SEED_FILES`								| _none_					| Path to SQL seed file glob(s) to execute during first time setup (separate by commas)
-`MYSQL_SERVICE_WAIT_INTERVAL`			| 1000						| Number of milliseconds to wait between MySQL service uptime test retries
-`MYSQL_SERVICE_WAIT_MAX_RETRIES`	| 30							| Maximum number of times to retry MySQL service uptime test before timing out
+### MySQL
+
+Key																| Required	| Default					| Description
+---																| ---				| ---							| ---
+`MYSQL_CHARSET`										| N					| utf8mb4					| Character set used to create a new MySQL database
+`MYSQL_COLLATE`										| N					| utf8mb4_bin			| Character collate used to create a new MySQL database
+`MYSQL_CONTAINER_NAME`						| Y					| _none_					| Name used to identify MySQL Service Docker container
+`MYSQL_DATABASE`									| Y					| _none_					| Name used to identify MySQL Service database
+`MYSQL_EXPOSED_PORT`							| Y					| 3306						| Local network port used to expose MySQL Service
+`MYSQL_IMAGE`											| Y					| _none_					| MySQL Server Docker image for your processor: https://hub.docker.com/r/mysql/mysql-server/tags
+`MYSQL_PATH`											| Y					| /var/lib/mysql	| Path to the preferred MySQL Service library file folder
+`MYSQL_ROOT_PASSWORD`							| Y					| _none_					| Password to use when creating the MySQL Service database root user
+`MYSQL_SEED_FILES`								| N					| _none_					| Path to SQL seed file glob(s) to execute during first time setup (separate by commas)
+`MYSQL_SERVICE_WAIT_INTERVAL`			| N					| 1000						| Number of milliseconds to wait between MySQL service uptime test retries
+`MYSQL_SERVICE_WAIT_MAX_RETRIES`	| N					| 30							| Maximum number of times to retry MySQL service uptime test before timing out
 
 <!--
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Key																| Required	| Default	| Description
 `MINIO_EXPOSED_WEB_PORT`					| Y					| 9001		| Local network port used to expose MinIO Web tool
 `MINIO_IMAGE`											| Y					| _none_	| MinIO Server Docker image for your processor: https://hub.docker.com/r/minio/minio/tags
 `MINIO_PATH`											| Y					| _none_	| Path to the preferred MinIO Service library file folder
+`MINIO_PUSH_FILES`								| N					| _none_	| Path to MinIO object storage file glob(s) to push (upload) during first time setup (separated by commas)
 `MINIO_ROOT_PASSWORD`							| Y					| _none_	| Username to use when creating the MinIO Service root user
 `MINIO_ROOT_USER`									| Y					| _none_	| Password to use when creating the MinIO Service root user
-`MINIO_SEED_FILES`								| N					| _none_	| Path to MinIO object storage seed file glob(s) to import during first time setup (separate by commas)
 `MINIO_SERVICE_WAIT_INTERVAL`			| N					| 1000		| Number of milliseconds to wait between MinIO service uptime test retries
 `MINIO_SERVICE_WAIT_MAX_RETRIES`	| N					| 30			| Maximum number of times to retry MinIO service uptime test before timing out
 
@@ -60,8 +60,8 @@ Key																| Required	| Default					| Description
 `MYSQL_EXPOSED_PORT`							| Y					| 3306						| Local network port used to expose MySQL Service
 `MYSQL_IMAGE`											| Y					| _none_					| MySQL Server Docker image for your processor: https://hub.docker.com/r/mysql/mysql-server/tags
 `MYSQL_PATH`											| Y					| /var/lib/mysql	| Path to the preferred MySQL Service library file folder
+`MYSQL_PUSH_FILES`								| N					| _none_					| Path to SQL file glob(s) to push (execute) during first time setup (separated by commas)
 `MYSQL_ROOT_PASSWORD`							| Y					| _none_					| Password to use when creating the MySQL Service database root user
-`MYSQL_SEED_FILES`								| N					| _none_					| Path to SQL seed file glob(s) to execute during first time setup (separate by commas)
 `MYSQL_SERVICE_WAIT_INTERVAL`			| N					| 1000						| Number of milliseconds to wait between MySQL service uptime test retries
 `MYSQL_SERVICE_WAIT_MAX_RETRIES`	| N					| 30							| Maximum number of times to retry MySQL service uptime test before timing out
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ Key																| Required	| Default					| Description
 `MYSQL_SERVICE_WAIT_INTERVAL`			| N					| 1000						| Number of milliseconds to wait between MySQL service uptime test retries
 `MYSQL_SERVICE_WAIT_MAX_RETRIES`	| N					| 30							| Maximum number of times to retry MySQL service uptime test before timing out
 
-<!--
+## License
 
-Official Docker Images
-https://github.com/docker-library/official-images/tree/master/library
+[MIT License](LICENSE)
 
--->

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -48,8 +48,8 @@ function showUsage() {
   console.info('');
   console.info('  config    Get service container config info');
   console.info('  create    Create new service container');
+  console.info('  push      Push data to service container');
   console.info('  remove    Remove service container');
-  console.info('  populate  Populate service container with existing data');
   console.info('  start     Start service container');
   console.info('  status    Get service container status info');
   console.info('  stop      Stop service container');
@@ -70,7 +70,7 @@ const commandName = args[1];
 const commands = [
   'config',
   'create',
-  'populate',
+  'push',
   'remove',
   'seed',
   'start',

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -34,24 +34,21 @@ class LocalService {
 function showUsage() {
   console.info('Usage: localservice [options] <service> <command>');
   console.info('');
-  console.info('Services:');
-  console.info('');
-  console.info('  minio     MinIO object storage (s3 compatible)');
-  console.info('  mysql     MySQL database');
-  console.info('');
-  console.info('Options:');
-  console.info('');
+  console.info('Options');
   console.info('  -v, --verbose   Show verbose info (e.g. raw docker commands, etc)');
   console.info('  -h, --help      Show this help screen');
   console.info('');
-  console.info('Commands:');
+  console.info('Services (implemented)');
+  console.info('  minio     MinIO object storage (s3 compatible)');
+  console.info('  mysql     MySQL database');
   console.info('');
+  console.info('Commands (universal)');
   console.info('  create    Create new service container');
-  console.info('  info      Get service container info');
-  console.info('  push      Push data to service container');
-  console.info('  remove    Remove service container');
-  console.info('  start     Start service container');
-  console.info('  stop      Stop service container');
+  console.info('  info      Get service config and container info');
+  console.info('  push      Push data to running service container');
+  console.info('  remove    Remove existing service container');
+  console.info('  start     Start stopped service container');
+  console.info('  stop      Stop running service container');
   process.exit();
 }
 

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -49,7 +49,7 @@ function showUsage() {
   console.info('  config    Get service container config info');
   console.info('  create    Create new service container');
   console.info('  remove    Remove service container');
-  console.info('  seed      Populate service container with seed data');
+  console.info('  populate  Populate service container with existing data');
   console.info('  start     Start service container');
   console.info('  status    Get service container status info');
   console.info('  stop      Stop service container');
@@ -70,6 +70,7 @@ const commandName = args[1];
 const commands = [
   'config',
   'create',
+  'populate',
   'remove',
   'seed',
   'start',

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -46,12 +46,11 @@ function showUsage() {
   console.info('');
   console.info('Commands:');
   console.info('');
-  console.info('  config    Get service container config info');
   console.info('  create    Create new service container');
+  console.info('  info      Get service container info');
   console.info('  push      Push data to service container');
   console.info('  remove    Remove service container');
   console.info('  start     Start service container');
-  console.info('  status    Get service container status info');
   console.info('  stop      Stop service container');
   process.exit();
 }
@@ -64,12 +63,18 @@ if (args.length && (args[0] === '-v' || args[0] === '--verbose')) {
   args.shift();
 }
 const serviceName = args[0];
-const commandName = args[1];
+let commandName = args[1];
 
 // usage
+const commandAliases = {
+  config: 'info',
+  seed: 'push',
+  status: 'info',
+};
 const commands = [
   'config',
   'create',
+  'info',
   'push',
   'remove',
   'seed',
@@ -77,6 +82,9 @@ const commands = [
   'status',
   'stop',
 ];
+if (Object.keys(commandAliases).includes(commandName)) {
+  commandName = commandAliases[commandName];
+}
 if (!serviceName || !commandName || !commands.includes(commandName)) {
   showUsage();
 }

--- a/library/minio.js
+++ b/library/minio.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 const {
   executeDocker,
   getContainerId,
@@ -153,11 +154,18 @@ class MinIOService {
    * Populate the existing MinIO Service container database with seed data
    * @return {Promise<Boolean>} seeded
    */
-  /* eslint-disable class-methods-use-this */
   async seed() {
     console.info('Seed is not implemented for MinIO');
+    return false;
   }
-  /* eslint-enable class-methods-use-this */
+
+  /**
+   * Alias populate to seed
+   * @return {Promise<Boolean>} seeded
+   */
+  populate() {
+    return this.seed();
+  }
 
   /**
    * Start the existing MinIO Service container

--- a/library/minio.js
+++ b/library/minio.js
@@ -3,8 +3,7 @@ const {
   executeDocker,
   getContainerId,
   isContainerRunning,
-  printConfig,
-  printStatus,
+  printInfo,
   verifyEnvironment,
 } = require('./util');
 
@@ -41,7 +40,7 @@ class MinIOService {
       MINIO_EXPOSED_WEB_PORT: {
         key: 'MINIO_EXPOSED_WEB_PORT',
         required: true,
-        description: 'Local network port used to expose MinIO Web Console',
+        description: 'Local network port used to expose MinIO Web tool',
         value: process.env.MINIO_EXPOSED_WEB_PORT || '9001',
         defaultValue: '9001',
       },
@@ -98,32 +97,6 @@ class MinIOService {
   }
 
   /**
-   * Print config information
-   * @param {Object} env
-   * @return {Promise}
-   */
-  async config() {
-    printConfig('MinIO', this.env);
-  }
-
-  /**
-   * Print status information
-   * @return {Promise}
-   */
-  async status() {
-    await verifyEnvironment(this.env);
-    const containerId = await getContainerId(
-      this.env.MINIO_CONTAINER_NAME.value,
-      this.options.verbose,
-    );
-    const containerRunning = await isContainerRunning(
-      this.env.MINIO_CONTAINER_NAME.value,
-      this.options.verbose,
-    );
-    printStatus('MinIO', containerId, containerRunning, containerRunning);
-  }
-
-  /**
    * Create a new MinIO Service container
    * @return {Promise<String>} containerId
    */
@@ -151,20 +124,20 @@ class MinIOService {
   }
 
   /**
+   * Print service container information
+   * @return {Promise}
+   */
+  async info() {
+    printInfo('MinIO', this.env, this.verbose);
+  }
+
+  /**
    * Push files up to the existing MinIO Service container bucket
    * @return {Promise<Boolean>} pushed
    */
   async push() {
     console.info('Push is not implemented for MinIO');
     return false;
-  }
-
-  /**
-   * Alias seed to push
-   * @return {Promise<Boolean>} pushed
-   */
-  seed() {
-    return this.push();
   }
 
   /**

--- a/library/minio.js
+++ b/library/minio.js
@@ -151,20 +151,20 @@ class MinIOService {
   }
 
   /**
-   * Populate the existing MinIO Service container database with seed data
-   * @return {Promise<Boolean>} seeded
+   * Push files up to the existing MinIO Service container bucket
+   * @return {Promise<Boolean>} pushed
    */
-  async seed() {
-    console.info('Seed is not implemented for MinIO');
+  async push() {
+    console.info('Push is not implemented for MinIO');
     return false;
   }
 
   /**
-   * Alias populate to seed
-   * @return {Promise<Boolean>} seeded
+   * Alias seed to push
+   * @return {Promise<Boolean>} pushed
    */
-  populate() {
-    return this.seed();
+  seed() {
+    return this.push();
   }
 
   /**

--- a/library/minio.js
+++ b/library/minio.js
@@ -58,6 +58,13 @@ class MinIOService {
         value: process.env.MINIO_PATH || '/data',
         defaultValue: '/data',
       },
+      MINIO_PUSH_FILES: {
+        key: 'MINIO_PUSH_FILES',
+        required: false,
+        description: 'Path to MinIO object storage file glob(s) to push (upload) during first time setup (separated by commas)',
+        value: process.env.MINIO_PUSH_FILES || process.env.MINIO_SEED_FILES || undefined,
+        defaultValue: undefined,
+      },
       MINIO_ROOT_USER: {
         key: 'MINIO_ROOT_USER',
         required: true,
@@ -85,13 +92,6 @@ class MinIOService {
         description: 'Maximum number of times to retry MinIO service uptime test before timing out',
         value: process.env.MINIO_SERVICE_WAIT_MAX_RETRIES || 30,
         defaultValue: 30,
-      },
-      MINIO_SEED_FILES: {
-        key: 'MINIO_SEED_FILES',
-        required: false,
-        description: 'Path to MinIO object storage seed file glob(s) to import during first time setup (separate by commas)',
-        value: process.env.MINIO_SEED_FILES || undefined,
-        defaultValue: undefined,
       },
     };
   }

--- a/library/mysql.js
+++ b/library/mysql.js
@@ -305,6 +305,14 @@ class MySQLService {
   }
 
   /**
+   * Alias populate to seed
+   * @return {Promise<Boolean>} seeded
+   */
+  populate() {
+    return this.seed();
+  }
+
+  /**
    * Start the existing MySQL Service container
    * @return {Promise<Boolean>} started
    */

--- a/library/mysql.js
+++ b/library/mysql.js
@@ -74,18 +74,18 @@ class MySQLService {
         value: process.env.MYSQL_PATH || '/var/lib/mysql',
         defaultValue: '/var/lib/mysql',
       },
+      MYSQL_PUSH_FILES: {
+        key: 'MYSQL_PUSH_FILES',
+        required: false,
+        description: 'Path to SQL file glob(s) to push (execute) during first time setup (separated by commas)',
+        value: process.env.MYSQL_PUSH_FILES || process.env.MYSQL_SEED_FILES || undefined,
+        defaultValue: undefined,
+      },
       MYSQL_ROOT_PASSWORD: {
         key: 'MYSQL_ROOT_PASSWORD',
         required: true,
         description: 'Password to use when creating the MySQL Service database root user',
         value: process.env.MYSQL_ROOT_PASSWORD || undefined,
-        defaultValue: undefined,
-      },
-      MYSQL_SEED_FILES: {
-        key: 'MYSQL_SEED_FILES',
-        required: false,
-        description: 'Path to SQL seed file glob(s) to execute during first time setup (separate by commas)',
-        value: process.env.MYSQL_SEED_FILES || undefined,
         defaultValue: undefined,
       },
       MYSQL_SERVICE_WAIT_INTERVAL: {

--- a/library/mysql.js
+++ b/library/mysql.js
@@ -5,7 +5,6 @@ const {
   getContainerId,
   isContainerRunning,
   printInfo,
-  printStatus,
   verifyEnvironment,
 } = require('./util');
 

--- a/library/mysql.js
+++ b/library/mysql.js
@@ -280,10 +280,10 @@ class MySQLService {
   }
 
   /**
-   * Populate the existing MySQL Service container database with seed data
-   * @return {Promise<Boolean>} seeded
+   * Push seed data to the existing MySQL Service container database
+   * @return {Promise<Boolean>} pushed
    */
-  async seed() {
+  async push() {
     await verifyEnvironment(this.env);
     const containerId = await getContainerId(
       this.env.MYSQL_CONTAINER_NAME.value,
@@ -305,11 +305,11 @@ class MySQLService {
   }
 
   /**
-   * Alias populate to seed
-   * @return {Promise<Boolean>} seeded
+   * Alias seed to push
+   * @return {Promise<Boolean>} pushed
    */
-  populate() {
-    return this.seed();
+  seed() {
+    return this.push();
   }
 
   /**

--- a/library/mysql.js
+++ b/library/mysql.js
@@ -4,7 +4,7 @@ const {
   findFilePaths,
   getContainerId,
   isContainerRunning,
-  printConfig,
+  printInfo,
   printStatus,
   verifyEnvironment,
 } = require('./util');
@@ -227,33 +227,6 @@ class MySQLService {
   }
 
   /**
-   * Print config information
-   * @param {Object} env
-   * @return {Promise}
-   */
-  async config() {
-    printConfig('MySQL', this.env);
-  }
-
-  /**
-   * Print status information
-   * @return {Promise}
-   */
-  async status() {
-    await verifyEnvironment(this.env);
-    const containerId = await getContainerId(
-      this.env.MYSQL_CONTAINER_NAME.value,
-      this.options.verbose,
-    );
-    const containerRunning = await isContainerRunning(
-      this.env.MYSQL_CONTAINER_NAME.value,
-      this.options.verbose,
-    );
-    const serviceReady = await this._isServiceReady();
-    printStatus('MySQL', containerId, containerRunning, serviceReady);
-  }
-
-  /**
    * Create a new MySQL Service container
    * @return {Promise<String>} containerId
    */
@@ -280,6 +253,14 @@ class MySQLService {
   }
 
   /**
+   * Print service container information
+   * @return {Promise}
+   */
+  async info() {
+    printInfo('MySQL', this.env, this.verbose);
+  }
+
+  /**
    * Push seed data to the existing MySQL Service container database
    * @return {Promise<Boolean>} pushed
    */
@@ -302,14 +283,6 @@ class MySQLService {
     await this._waitUntilServiceIsReady();
     await this._seedDatabase();
     return true;
-  }
-
-  /**
-   * Alias seed to push
-   * @return {Promise<Boolean>} pushed
-   */
-  seed() {
-    return this.push();
   }
 
   /**

--- a/library/util.js
+++ b/library/util.js
@@ -56,21 +56,23 @@ const isContainerRunning = async (containerName, verbose = false) => {
 };
 
 /**
- * Print config information
+ * Print service container information
  * @param {String} displayServiceName
  * @param {Object} env
+ * @param {Boolean} verbose [default=false]
  * @return {Promise}
  */
-const printConfig = async (displayServiceName, env) => {
-  console.info(`${displayServiceName} Configuration:`);
+const printInfo = async (displayServiceName, env, verbose = false) => {
+  console.info(`${displayServiceName} Environment Variables:`);
   console.info('');
+  const minWidth = 16;
   const keys = Object.keys(env);
   const values = Object.values(env).map((obj) => obj.value || '');
   const defaultValues = Object.values(env).map((obj) => obj.defaultValue || '');
-  const lengthComparator = (a, b) => ((a.length > b.length) ? a : b);
-  const keyLength = Math.max(10, keys.reduce(lengthComparator, '').length + 3);
-  const defaultValueLength = Math.max(10, defaultValues.reduce(lengthComparator, '').length + 3);
-  const valueLength = Math.max(10, values.reduce(lengthComparator, '').length + 3);
+  const lengthComparator = (a, b) => ((a.toString().length > b.toString().length) ? a : b);
+  const keyLength = Math.max(minWidth, keys.reduce(lengthComparator, '').length + 3);
+  const defaultValueLength = Math.max(minWidth, defaultValues.reduce(lengthComparator, '').length + 3);
+  const valueLength = Math.max(minWidth, values.reduce(lengthComparator, '').length + 3);
   console.info([
     '  ',
     'Key'.padEnd(keyLength),
@@ -80,36 +82,56 @@ const printConfig = async (displayServiceName, env) => {
   ].join(''));
   console.info([
     '  ',
-    '-'.repeat(keyLength - 3), '   ',
-    '-'.repeat(defaultValueLength - 3), '   ',
-    '-'.repeat(valueLength - 3), '   ',
-    '-'.repeat(8),
+    '-'.repeat(keyLength - 3).padEnd(keyLength),
+    '-'.repeat(defaultValueLength - 3).padEnd(defaultValueLength),
+    '-'.repeat(valueLength - 3).padEnd(valueLength),
+    '-'.repeat(8).padEnd(11),
   ].join(''));
   keys.forEach((key) => {
     console.info([
       '  ',
       key.padEnd(keyLength),
       (env[key].defaultValue || '').toString().padEnd(defaultValueLength),
-      (env[key].value || 'none').toString().padEnd(valueLength),
+      (env[key].value || '').toString().padEnd(valueLength),
       (env[key].required ? 'Y' : 'N').padEnd(11),
     ].join(''));
   });
-};
-
-/**
- * Print status information
- * @param {String} displayServiceName
- * @param {String} containerId
- * @param {Boolean} containerRunning
- * @param {Boolean} serviceReady
- * @return {Promise}
- */
-const printStatus = async (displayServiceName, containerId, containerRunning, serviceReady) => {
-  console.info(`${displayServiceName} Status:`);
   console.info('');
-  console.info(`  Container ID      ${containerId || 'Unknown'}`);
-  console.info(`  Container Status  ${!containerId ? 'N/A' : (containerRunning ? 'Running' : 'Stopped')}`);
-  console.info(`  Service Status    ${!containerId ? 'N/A' : (serviceReady ? 'Ready' : 'Not Ready')}`);
+  console.info(`${displayServiceName} Container Status:`);
+  console.info('');
+  const containerId = await getContainerId(
+    env[`${displayServiceName.toUpperCase()}_CONTAINER_NAME`].value,
+    verbose,
+  );
+  const containerRunning = await isContainerRunning(
+    env[`${displayServiceName.toUpperCase()}_CONTAINER_NAME`].value,
+    verbose,
+  );
+  console.info([
+    '  ',
+    'Name'.padEnd(minWidth + 3),
+    'Value'.padEnd(minWidth + 3),
+  ].join(''));
+  console.info([
+    '  ',
+    '-'.repeat(minWidth).padEnd(minWidth + 3),
+    '-'.repeat(minWidth).padEnd(minWidth + 3),
+  ].join(''));
+  console.info([
+    '  ',
+    'Container Name'.padEnd(minWidth + 3),
+    `${env[`${displayServiceName.toUpperCase()}_CONTAINER_NAME`].value || 'Undefined'}`.padEnd(minWidth),
+  ].join(''));
+  console.info([
+    '  ',
+    'Container ID'.padEnd(minWidth + 3),
+    `${containerId || 'Unknown'}`.padEnd(minWidth),
+  ].join(''));
+  console.info([
+    '  ',
+    'Container Status'.padEnd(minWidth + 3),
+    `${!containerId ? 'N/A' : (containerRunning ? 'Running' : 'Stopped')}`.padEnd(minWidth),
+  ].join(''));
 };
 
 /**
@@ -137,7 +159,6 @@ module.exports = {
   findFilePaths,
   getContainerId,
   isContainerRunning,
-  printConfig,
-  printStatus,
+  printInfo,
   verifyEnvironment,
 };

--- a/library/util.js
+++ b/library/util.js
@@ -67,6 +67,14 @@ const printInfo = async (displayServiceName, env, verbose = false) => {
   const minWidth = 16;
 
   // Environment Variables
+  let verified = true;
+  let verifiedError = undefined;
+  try {
+    verified = await verifyEnvironment(env);
+  } catch (err) {
+    verified = false;
+    verifiedError = err.message;
+  }
   const keys = Object.keys(env);
   const values = Object.values(env).map((obj) => obj.value || '');
   const defaultValues = Object.values(env).map((obj) => obj.defaultValue || '');
@@ -100,6 +108,11 @@ const printInfo = async (displayServiceName, env, verbose = false) => {
       (env[key].value || '').toString().padEnd(valueLength),
     ].join(''));
   });
+  if (verifiedError) {
+    console.info(`  ${'~ '.repeat((keyLength + 11 + defaultValueLength + valueLength - 3) / 2)}`);
+    console.info('  ERROR');
+    console.info(`  ${verifiedError}`);
+  }
 
   // Divider
   console.info();
@@ -108,6 +121,11 @@ const printInfo = async (displayServiceName, env, verbose = false) => {
   console.info(`  ${headerCharacter.repeat((minWidth + 3) * 2 - 3)}`);
   console.info(`  ${displayServiceName} Container Status`);
   console.info(`  ${headerCharacter.repeat((minWidth + 3) * 2 - 3)}`);
+  if (verifiedError) {
+    console.info('  ERROR');
+    console.info('  Container status commands will not run until env var errors are resolved');
+    return;
+  }
   const containerId = await getContainerId(
     env[`${displayServiceName.toUpperCase()}_CONTAINER_NAME`].value,
     verbose,

--- a/library/util.js
+++ b/library/util.js
@@ -68,9 +68,9 @@ const printConfig = async (displayServiceName, env) => {
   const values = Object.values(env).map((obj) => obj.value || '');
   const defaultValues = Object.values(env).map((obj) => obj.defaultValue || '');
   const lengthComparator = (a, b) => ((a.length > b.length) ? a : b);
-  const keyLength = keys.reduce(lengthComparator, '').length + 3;
-  const defaultValueLength = defaultValues.reduce(lengthComparator, '').length + 3;
-  const valueLength = values.reduce(lengthComparator, '').length + 3;
+  const keyLength = Math.max(10, keys.reduce(lengthComparator, '').length + 3);
+  const defaultValueLength = Math.max(10, defaultValues.reduce(lengthComparator, '').length + 3);
+  const valueLength = Math.max(10, values.reduce(lengthComparator, '').length + 3);
   console.info([
     '  ',
     'Key'.padEnd(keyLength),

--- a/library/util.js
+++ b/library/util.js
@@ -63,9 +63,10 @@ const isContainerRunning = async (containerName, verbose = false) => {
  * @return {Promise}
  */
 const printInfo = async (displayServiceName, env, verbose = false) => {
-  console.info(`${displayServiceName} Environment Variables:`);
-  console.info('');
+  const headerCharacter = '=';
   const minWidth = 16;
+
+  // Environment Variables
   const keys = Object.keys(env);
   const values = Object.values(env).map((obj) => obj.value || '');
   const defaultValues = Object.values(env).map((obj) => obj.defaultValue || '');
@@ -73,32 +74,40 @@ const printInfo = async (displayServiceName, env, verbose = false) => {
   const keyLength = Math.max(minWidth, keys.reduce(lengthComparator, '').length + 3);
   const defaultValueLength = Math.max(minWidth, defaultValues.reduce(lengthComparator, '').length + 3);
   const valueLength = Math.max(minWidth, values.reduce(lengthComparator, '').length + 3);
+  console.info(`  ${headerCharacter.repeat(keyLength + 11 + defaultValueLength + valueLength - 3)}`);
+  console.info(`  ${displayServiceName} Environment Variables`);
+  console.info(`  ${headerCharacter.repeat(keyLength + 11 + defaultValueLength + valueLength - 3)}`);
   console.info([
     '  ',
     'Key'.padEnd(keyLength),
+    'Required'.padEnd(11),
     'Default'.padEnd(defaultValueLength),
     'Value'.padEnd(valueLength),
-    'Required'.padEnd(11),
   ].join(''));
   console.info([
     '  ',
     '-'.repeat(keyLength - 3).padEnd(keyLength),
+    '-'.repeat(8).padEnd(11),
     '-'.repeat(defaultValueLength - 3).padEnd(defaultValueLength),
     '-'.repeat(valueLength - 3).padEnd(valueLength),
-    '-'.repeat(8).padEnd(11),
   ].join(''));
   keys.forEach((key) => {
     console.info([
       '  ',
       key.padEnd(keyLength),
+      (env[key].required ? 'Y' : 'N').padEnd(11),
       (env[key].defaultValue || '').toString().padEnd(defaultValueLength),
       (env[key].value || '').toString().padEnd(valueLength),
-      (env[key].required ? 'Y' : 'N').padEnd(11),
     ].join(''));
   });
-  console.info('');
-  console.info(`${displayServiceName} Container Status:`);
-  console.info('');
+
+  // Divider
+  console.info();
+
+  // Container Status
+  console.info(`  ${headerCharacter.repeat((minWidth + 3) * 2 - 3)}`);
+  console.info(`  ${displayServiceName} Container Status`);
+  console.info(`  ${headerCharacter.repeat((minWidth + 3) * 2 - 3)}`);
   const containerId = await getContainerId(
     env[`${displayServiceName.toUpperCase()}_CONTAINER_NAME`].value,
     verbose,
@@ -109,7 +118,7 @@ const printInfo = async (displayServiceName, env, verbose = false) => {
   );
   console.info([
     '  ',
-    'Name'.padEnd(minWidth + 3),
+    'Subject'.padEnd(minWidth + 3),
     'Value'.padEnd(minWidth + 3),
   ].join(''));
   console.info([

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Install and manage local services for your development environments",
   "keywords": "node cli docker local service development environment dotenv",
   "main": "./bin/localservice.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Install and manage local services for your development environments",
   "keywords": "node cli docker local service development environment dotenv",
   "main": "./bin/localservice.js",


### PR DESCRIPTION
# Rename `seed` to `push`, combine `config`/`status` into `info`

The term `seed` is fairly specific to databases, but not every service being added to this project will be a database (per se). Since this command is meant to generically apply to all implemented services the term `push` seems more appropriate (e.g. you can `push` data, files, configurations, hashes, etc to many different kinds of service containers).

Asking users to consistently test `config` output and `status` output separately from one another isn't necessary. These two outputs have been combined.

Both of these changes are to make `localservice` easier to use.

## Changes

- Rename `seed` command to `push`
- Combine `config` and `status` into `info`
- Improve combined print output for `info` command
- Add backward compatible aliases for `config`, `seed`, and `status`
- Add MinIO and MySQL environment variables to `README`
- Add MIT `LICENSE` link to `README`
- Rename `*_SEED_FILES` to `*_PUSH_FILES`
- Add backward compatible aliases for `*_SEED_FILES`
- Bump patch version to `0.6.0`

## Testing

```
npx localservice mysql info
npx localservice mysql push
npx localservice minio info
npx localservice minio push
```