### PR TITLE
Fix `info` aliases

### DIFF
--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -44,7 +44,7 @@ function showUsage() {
   console.info('');
   console.info('Commands (universal)');
   console.info('  create    Create new service container');
-  console.info('  info      Get service config and container info');
+  console.info('  info      Get service env and container info');
   console.info('  push      Push data to running service container');
   console.info('  remove    Remove existing service container');
   console.info('  start     Start stopped service container');
@@ -65,18 +65,16 @@ let commandName = args[1];
 // usage
 const commandAliases = {
   config: 'info',
+  env: 'info',
   seed: 'push',
   status: 'info',
 };
 const commands = [
-  'config',
   'create',
   'info',
   'push',
   'remove',
-  'seed',
   'start',
-  'status',
   'stop',
 ];
 if (Object.keys(commandAliases).includes(commandName)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Install and manage local services for your development environments",
   "keywords": "node cli docker local service development environment dotenv",
   "main": "./bin/localservice.js",


### PR DESCRIPTION
# Fix `info` aliases

There was a bug in the `0.6.0` push involving the `info` aliases. They used to be hard-coded alias methods, but they are now argument mappings. This update was missed.

## Changes

- Fix `info` aliases for `config`, `seed`, `status` (all are backwards compatible with `info`)
- Add `env` alias for `info` (seemed like a common command Users might try)
- Bump patch version to `0.6.1`

## Testing

The correct command is `info`, but all of the below commands will yield the same result. These aliases might be removed when we go to `1.0.0`.

```
npx localservice mysql config
npx localservice mysql env
npx localservice mysql info
npx localservice mysql seed
npx localservice mysql status
```