### PR TITLE
Implement `commander` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Install and manage services for your local development environments.
 [~] npx localservice -h
 Usage: npx localservice [options] [command]
 
-Manage local services (utilizes Docker)
+Manage local services (using Docker):
+  minio             MinIO object storage (s3 compatible)
+  mysql             MySQL database
+  postgres          PostgreSQL database
 
 Options:
   -V, --version     output the version number

--- a/README.md
+++ b/README.md
@@ -12,25 +12,23 @@ Install and manage services for your local development environments.
 ```text
 [~] npm i localservice
 [~] npx localservice -h
+Usage: npx localservice [options] [command]
 
-Usage: localservice [options] <service> <command>
+Manage local services (utilizes Docker)
 
-Options
-  -v, --verbose   Show verbose info (e.g. raw docker commands, etc)
-  -h, --help      Show this help screen
+Options:
+  -V, --version     output the version number
+  -v, --verbose     output verbose info (e.g. raw Docker commands)
+  -h, --help        display general help and usage info
 
-Services (implemented)
-  minio     MinIO object storage (s3 compatible)
-  mysql     MySQL database
-	postgres  PostgreSQL database
-
-Commands (universal)
-  create    Create new service container
-  info      Get service env and container info
-  push      Push data to running service container
-  remove    Remove existing service container
-  start     Start stopped service container
-  stop      Stop running service container
+Commands:
+  info <service>    Display service info (env vars and container status)
+  create <service>  Create service container
+  stop <service>    Stop service container
+  start <service>   Start service container
+  push <service>    Push data to service
+  remove <service>  Remove service container
+  help <command>    Display help for specific <command>
 ```
 
 ## Environment Variables

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -65,7 +65,7 @@ program.on('option:verbose', () => {
 // support info command
 program.command('info')
   // .aliases(['config', 'status'])
-  .description('Display service info')
+  .description('Display service info (env vars and container status)')
   .argument('<service>', 'container service')
   .action((service) => execute(service, 'info'));
 

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -102,19 +102,5 @@ program.command('remove')
   .argument('<service>', 'container service')
   .action((service) => execute(service, 'remove'));
 
-// support legacy aliases (silently)
-const legacyAliases = {
-  config: 'info',
-  env: 'info',
-  seed: 'push',
-  status: 'info',
-};
-const args = process.argv;
-Object.keys(legacyAliases).forEach((key) => {
-  if (args[2] === key) {
-    args[2] = legacyAliases[key];
-  }
-});
-
 // parse command line arguments
-program.parse(args);
+program.parse();

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -105,7 +105,7 @@ program.command('remove')
   .argument('<service>', 'container service')
   .action((service) => execute(service, 'remove'));
 
-// auto correct deprecated command line argument order
+// auto correct legacy command line argument order
 // @todo: remove this workaround before version 1.0.0 is released
 const args = [...process.argv];
 const services = ['minio', 'mysql', 'postgres'];
@@ -128,11 +128,11 @@ if (legacy.reduce((a, b) => a + b) !== -2) {
   console.warn(`  ${['!!', '~ '.repeat(39)].join(' ').padEnd(81)}!!`);
   console.warn(`  ${'!! WARNING'.padEnd(81, ' ')}!!`);
   console.warn(`  ${'!!'.padEnd(81, ' ')}!!`);
-  console.warn(`  ${'!! Deprecated command line argument order was detected and auto corrected.'.padEnd(81, ' ')}!!`);
+  console.warn(`  ${'!! Deprecated command line argument usage was detected and auto corrected:'.padEnd(81, ' ')}!!`);
   console.warn(`  ${['!! -- npx localservice ', process.argv.slice(2).join(' ')].join('').padEnd(81, ' ')}!!`);
   console.warn(`  ${['!! ++ npx localservice ', args.slice(2).join(' ')].join('').padEnd(81, ' ')}!!`);
   console.warn(`  ${'!!'.padEnd(81, ' ')}!!`);
-  console.warn(`  ${'!! Update your implementation, this workaround will be removed in the future.'.padEnd(81, ' ')}!!`);
+  console.warn(`  ${'!! This auto correction will not be carried forward into version 1.0.0.'.padEnd(81, ' ')}!!`);
   console.warn(`  ${['!!', '~ '.repeat(39)].join(' ').padEnd(81)}!!`);
   console.warn();
 }

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -121,8 +121,10 @@ args.forEach((arg, idx) => {
 });
 if (legacy.reduce((a, b) => a + b) !== -2) {
   const swap = [args[legacy[0]], args[legacy[1]]];
+  /* eslint-disable prefer-destructuring */
   args[legacy[0]] = swap[1];
   args[legacy[1]] = swap[0];
+  /* eslint-enable prefer-destructuring */
   console.warn(`  ${['!!', '~ '.repeat(39)].join(' ').padEnd(81)}!!`);
   console.warn(`  ${'!! WARNING'.padEnd(81, ' ')}!!`);
   console.warn(`  ${'!!'.padEnd(81, ' ')}!!`);

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -102,47 +102,19 @@ program.command('remove')
   .argument('<service>', 'container service')
   .action((service) => execute(service, 'remove'));
 
-// parse command line arguments
-program.parse();
+// support legacy aliases (silently)
+const legacyAliases = {
+  config: 'info',
+  env: 'info',
+  seed: 'push',
+  status: 'info',
+};
+const args = process.argv;
+Object.keys(legacyAliases).forEach((key) => {
+  if (args[2] === key) {
+    args[2] = legacyAliases[key];
+  }
+});
 
-// // cli args
-// const args = process.argv.slice(2);
-// let verbose = false;
-// if (args.length && (args[0] === '-v' || args[0] === '--verbose')) {
-//   verbose = true;
-//   args.shift();
-// }
-// const serviceName = args[0];
-// let commandName = args[1];
-//
-// // usage
-// const commandAliases = {
-//   config: 'info',
-//   env: 'info',
-//   seed: 'push',
-//   status: 'info',
-// };
-// const commands = [
-//   'create',
-//   'info',
-//   'push',
-//   'remove',
-//   'start',
-//   'stop',
-// ];
-// if (Object.keys(commandAliases).includes(commandName)) {
-//   commandName = commandAliases[commandName];
-// }
-// if (!serviceName || !commandName || !commands.includes(commandName)) {
-//   showUsage();
-// }
-//
-// // run
-// const localService = new LocalService(serviceName, {
-//   cwd: process.cwd(),
-//   verbose,
-// });
-// localService.service[commandName]().catch((err) => {
-//   console.error(err.message);
-//   process.exit(1);
-// });
+// parse command line arguments
+program.parse(args);

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -51,7 +51,10 @@ const execute = (serviceName, commandName) => {
 // configure program
 program
   .name('npx localservice')
-  .description('Manage local services (utilizes Docker)')
+  .description(`Manage local services (using Docker):
+  minio             MinIO object storage (s3 compatible)
+  mysql             MySQL database
+  postgres          PostgreSQL database`)
   .version(version)
   .option('-v, --verbose', 'output verbose info (e.g. raw Docker commands)')
   .helpOption('-h, --help', 'display general help and usage info')

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -102,5 +102,35 @@ program.command('remove')
   .argument('<service>', 'container service')
   .action((service) => execute(service, 'remove'));
 
+// auto correct deprecated command line argument order
+// @todo: remove this workaround before version 1.0.0 is released
+const args = [...process.argv];
+const services = ['minio', 'mysql', 'postgres'];
+const commands = program.commands.map((command) => command._name);
+const legacy = [-1, -1];
+args.forEach((arg, idx) => {
+  if (legacy[0] === -1 && services.includes(arg)) {
+    legacy[0] = idx;
+  }
+  if (legacy[1] === -1 && commands.includes(arg)) {
+    legacy[1] = idx;
+  }
+});
+if (legacy.reduce((a, b) => a + b) !== -2) {
+  const swap = [args[legacy[0]], args[legacy[1]]];
+  args[legacy[0]] = swap[1];
+  args[legacy[1]] = swap[0];
+  console.warn(`  ${['!!', '~ '.repeat(39)].join(' ').padEnd(81)}!!`);
+  console.warn(`  ${'!! WARNING'.padEnd(81, ' ')}!!`);
+  console.warn(`  ${'!!'.padEnd(81, ' ')}!!`);
+  console.warn(`  ${'!! Deprecated command line argument order was detected and auto corrected.'.padEnd(81, ' ')}!!`);
+  console.warn(`  ${['!! -- npx localservice ', process.argv.slice(2).join(' ')].join('').padEnd(81, ' ')}!!`);
+  console.warn(`  ${['!! ++ npx localservice ', args.slice(2).join(' ')].join('').padEnd(81, ' ')}!!`);
+  console.warn(`  ${'!!'.padEnd(81, ' ')}!!`);
+  console.warn(`  ${'!! Update your implementation, this workaround will be removed in the future.'.padEnd(81, ' ')}!!`);
+  console.warn(`  ${['!!', '~ '.repeat(39)].join(' ').padEnd(81)}!!`);
+  console.warn();
+}
+
 // parse command line arguments
-program.parse();
+program.parse(args);

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -51,7 +51,7 @@ const execute = (serviceName, commandName) => {
 // configure program
 program
   .name('npx localservice')
-  .description(`Manage local services (using Docker):
+  .description(`Supported Services:
   minio             MinIO object storage (s3 compatible)
   mysql             MySQL database
   postgres          PostgreSQL database`)

--- a/library/mysql.js
+++ b/library/mysql.js
@@ -141,7 +141,6 @@ class MySQLService {
       }
       return false;
     } catch (err) {
-      // console.warn('_isServiceReady', { err });
       return false;
     }
   }

--- a/library/util.js
+++ b/library/util.js
@@ -56,6 +56,26 @@ const isContainerRunning = async (containerName, verbose = false) => {
 };
 
 /**
+ * Verify service defined environment variables
+ * @param {Object} env
+ * @return {Promise<Boolean>}
+ */
+const verifyEnvironment = async (env) => {
+  const missing = [];
+  Object.keys(env).forEach((key) => {
+    if (env[key].required) {
+      if (!env[key].value) {
+        missing.push(key);
+      }
+    }
+  });
+  if (missing.length) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+  return true;
+};
+
+/**
  * Print service container information
  * @param {String} displayServiceName
  * @param {Object} env
@@ -67,12 +87,10 @@ const printInfo = async (displayServiceName, env, verbose = false) => {
   const minWidth = 16;
 
   // Environment Variables
-  let verified = true;
-  let verifiedError = undefined;
+  let verifiedError;
   try {
-    verified = await verifyEnvironment(env);
+    await verifyEnvironment(env);
   } catch (err) {
-    verified = false;
     verifiedError = err.message;
   }
   const keys = Object.keys(env);
@@ -159,26 +177,6 @@ const printInfo = async (displayServiceName, env, verbose = false) => {
     'Container Status'.padEnd(minWidth + 3),
     `${!containerId ? 'N/A' : (containerRunning ? 'Running' : 'Stopped')}`.padEnd(minWidth),
   ].join(''));
-};
-
-/**
- * Verify service defined environment variables
- * @param {Object} env
- * @return {Promise<Boolean>}
- */
-const verifyEnvironment = async (env) => {
-  const missing = [];
-  Object.keys(env).forEach((key) => {
-    if (env[key].required) {
-      if (!env[key].value) {
-        missing.push(key);
-      }
-    }
-  });
-  if (missing.length) {
-    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
-  }
-  return true;
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.1.0",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -339,6 +339,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
+    },
+    "commander": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "localservice",
   "version": "0.8.0",
-  "description": "Install and manage local services for your development environments",
-  "keywords": "node cli docker local service development environment dotenv",
+  "description": "Manage local services (using Docker)",
+  "keywords": "node cli docker local service development environment dotenv minio mysql postgres",
   "main": "./bin/localservice.js",
   "bin": {
     "localservice": "./bin/localservice.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Install and manage local services for your development environments",
   "keywords": "node cli docker local service development environment dotenv",
   "main": "./bin/localservice.js",
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/tobiusventures/localservice#readme",
   "dependencies": {
+    "commander": "^9.4.1",
     "docker-cli-js": "^2.9.0",
     "dotenv": "^16.0.1",
     "fast-glob": "^3.2.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "description": "Install and manage local services for your development environments",
   "keywords": "node cli docker local service development environment dotenv",
   "main": "./bin/localservice.js",


### PR DESCRIPTION
# Implement `commander` interface

Refactoring the CLI logic to utilize the `commander` interface library will make it easier to implement new commands, options, examples, etc in the future. Visit [npmjs.com/commander](https://npmjs.com/commander) for more information.

__New CLI Usage__

```
Usage: npx localservice [options] [command]

Supported Services:
  minio             MinIO object storage (s3 compatible)
  mysql             MySQL database
  postgres          PostgreSQL database

Options:
  -V, --version     output the version number
  -v, --verbose     output verbose info (e.g. raw Docker commands)
  -h, --help        display general help and usage info

Commands:
  info <service>    Display service info (env vars and container status)
  create <service>  Create service container
  stop <service>    Stop service container
  start <service>   Start service container
  push <service>    Push data to service
  remove <service>  Remove service container
  help <command>    Display help for specific <command>
```

__Important!__

This PR swaps the CLI signature order for service and command (e.g. `mysql create` becomes `create mysql`). Since this is obviously a backward breaking change this PR "should" be promoted to `1.0.0`, but because many Developers see that as the author claiming a sign of hardened stability (which we're not quite far enough along for yet) this PR instead has included a backward compatible workaround that detects and re-orders the service and command arguments when in the wrong order.

This PR also re-implements the existing backwards compatible support for legacy command aliases (e.g. `config|env|status` map to `info`, `seed` maps to `push`, ala `mysql env` gets remapped to `info mysql`, and so forth).

These workarounds will not survive the eventual `1.0.0` release. A deprecation warning will be output until that time to remind Developers to update their usage.

```
[~] ./bin/localservice mysql info
  !! ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ !!
  !! WARNING                                                                       !!
  !!                                                                               !!
  !! Deprecated command line usage was detected and auto corrected:                !!
  !! -- npx localservice mysql env                                                 !!
  !! ++ npx localservice info mysql                                                !!
  !!                                                                               !!
  !! These auto corrections will not survive the upcoming version 1.0.0 release,   !!
  !! please remember to update your command line usage before upgrading.           !!
  !! ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ !!

  ...
```

## Changes

- Refactor CLI to use the `commander` library
- Update `-h, --help` output structure
- Add `-V, --version` option to output the current `localservice` version
- Reorder arguments from `<service> <command>` to `<command> <service>`
- Add `help <command>` support for individualized command instructions
- Add backward compatible argument order support (postponing `1.0.0` release)
- Add backward compatible command alias support (postponing `1.0.0` release)
- Bump the patch version to `0.8.0`

## Testing

CLI signature has changed for all commands. Re-test everything.

```
[~] ./bin/localservice.js
```

_Note: Use `npx localservice` if running from `npm i`._