### PR TITLE
Fix argument order bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install and manage services for your local development environments.
 [~] npx localservice -h
 Usage: npx localservice [options] [command]
 
-Manage local services (using Docker):
+Supported Services:
   minio             MinIO object storage (s3 compatible)
   mysql             MySQL database
   postgres          PostgreSQL database

--- a/bin/localservice.js
+++ b/bin/localservice.js
@@ -137,11 +137,20 @@ if (order[0] !== -1 && order[1] === -1) {
     });
   });
 }
-if (order[0] !== -1 && order[1] !== -1) {
+if ((order[0] !== -1 && order[1] !== -1) && ((order[1] > order[0]) || legacyCommand)){
   const swap = [args[order[0]], args[order[1]]];
   /* eslint-disable prefer-destructuring */
-  args[order[0]] = legacyCommand || swap[1];
-  args[order[1]] = swap[0];
+  if (legacyCommand) {
+    if (order[1] < order[0]) {
+      args[order[1]] = legacyCommand;
+    } else {
+      swap[1] = legacyCommand;
+    }
+  }
+  if (order[1] > order[0]) {
+    args[order[0]] = swap[1];
+    args[order[1]] = swap[0];
+  }
   /* eslint-enable prefer-destructuring */
   console.warn(`  ${['!!', '~ '.repeat(39)].join(' ').padEnd(81)}!!`);
   console.warn(`  ${'!! WARNING'.padEnd(81, ' ')}!!`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Manage local services (using Docker)",
   "keywords": "node cli docker local service development environment dotenv minio mysql postgres",
   "main": "./bin/localservice.js",


### PR DESCRIPTION
# Fix argument order bug

There were several scenarios were detected shortly after `0.8.0` was pushed. They are all accounted for in this PR.

## Changes

- Fix bugs causing legacy arguments to be remapped incorrectly
- Bump patch version to `v0.8.1`

## Testing

The first command should run with no warnings. The next three commands should run successfully as well, but with the legacy support warnings.

```
npx localservice mysql info
npx localservice mysql env
npx localservice info mysql
npx localservice env mysql
```