### PR TITLE
Fix broken sleep functions

### DIFF
--- a/library/mysql.js
+++ b/library/mysql.js
@@ -5,6 +5,7 @@ const {
   getContainerId,
   isContainerRunning,
   printInfo,
+  sleep,
   verifyEnvironment,
 } = require('./util');
 
@@ -152,7 +153,6 @@ class MySQLService {
   async _waitUntilServiceIsReady() {
     let count = 0;
     let isReady = false;
-    const sleep = () => setTimeout(() => undefined, this.env.MYSQL_SERVICE_WAIT_INTERVAL.value);
     /* eslint-disable no-await-in-loop */
     while (count < this.env.MYSQL_SERVICE_WAIT_MAX_RETRIES.value) {
       isReady = await this._isServiceReady();
@@ -160,7 +160,7 @@ class MySQLService {
         return true;
       }
       count += 1;
-      await sleep();
+      await sleep(this.env.MYSQL_SERVICE_WAIT_INTERVAL.value);
     }
     /* eslint-enable no-await-in-loop */
     throw new Error('MySQL service took too long to start, please try again (or update `MYSQL_SERVICE_WAIT_*` settings)');

--- a/library/util.js
+++ b/library/util.js
@@ -180,11 +180,19 @@ const printInfo = async (displayServiceName, env, verbose = false) => {
   ].join(''));
 };
 
+/**
+ * Sleep for x milliseconds
+ * @param {Integer} ms
+ * @return {Promise}
+ */
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 module.exports = {
   executeDocker,
   findFilePaths,
   getContainerId,
   isContainerRunning,
   printInfo,
+  sleep,
   verifyEnvironment,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localservice",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Manage local services (using Docker)",
   "keywords": "node cli docker local service development environment dotenv minio mysql postgres",
   "main": "./bin/localservice.js",


### PR DESCRIPTION
# Fix broken sleep functions

The sleep timers in both of the `mysql` and `postgres` library implementations were broken (e.g. not working at all). This was causing unexpected performance behaviors across machines of various hardware levels.

## Changes

- Add shared `sleep` function to `util`
- Replace broken `sleep` timers in `mysql` and `postgres` libs with new `sleep` function
- Bump patch version to `0.8.2`

## Testing

Fast machines never seemed to notice this issue, but there is an easy way to test it.

Install version `0.8.1` and set the following env vars (I'm using PostgreSQL but you can also do this for MySQL):

```
POSTGRES_CONTAINER_NAME=foo-bar-postgres
POSTGRES_DATABASE=foo_bar
POSTGRES_EXPOSED_PORT=5432
POSTGRES_IMAGE=postgres:13-alpine
POSTGRES_PATH=/var/lib/postgresql/data
POSTGRES_SUPER_USER=thetestman
POSTGRES_SUPER_PASSWORD=thetestpassword
POSTGRES_SERVICE_WAIT_INTERVAL=5000
```

The `*_WAIT_INTERVAL` is the important bit, you should see 5 second delays between each test to see if the service is ready yet, but you won't, it will scream through them. Spin it up!

```
npx localservice -v create postgres
```

Now do the same thing, but with this branch (version `0.8.2`) and you'll see that the 5 second delay is working as expected. Setting the `-v` (verbose) flag makes this result easier to understand.